### PR TITLE
Make `apt_cacher_ng__connect_protocol` configurable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ v0.2.0
 - | Renamed ``apt_cacher_ng__nginx_upstream`` to ``apt_cacher_ng__nginx__upstream``.
   | Renamed ``apt_cacher_ng__nginx_upstream_servers`` to ``apt_cacher_ng__upstream_servers``. [ypid]
 
+- Added :any:`apt_cacher_ng__connect_protocol` to allow to specify which IP
+  version to prefer when contacting upstream mirrors. [ypid]
+
 v0.1.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@ v0.2.0
 
 *Unreleased*
 
-- | Renamed ``apt_cacher_ng__nginx_upstream`` to ``apt_cacher_ng__nginx__upstream``.
-  | Renamed ``apt_cacher_ng__nginx_upstream_servers`` to ``apt_cacher_ng__upstream_servers``. [ypid]
+- | Renamed ``apt_cacher_ng__nginx_upstream`` to :any:`apt_cacher_ng__nginx__upstream`.
+  | Renamed ``apt_cacher_ng__nginx_upstream_servers`` to :any:`apt_cacher_ng__upstream_servers`. [ypid]
 
 - Added :any:`apt_cacher_ng__connect_protocol` to allow to specify which IP
   version to prefer when contacting upstream mirrors. [ypid]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -449,7 +449,7 @@ apt_cacher_ng__apt_preferences__dependent_list:
 
   - package: 'apt-cacher-ng'
     backports: [ 'wheezy', 'jessie' ]
-    reason:  'http://httpredir.debian.org/debian is not included in the deb_mirrors.gz file of apt-cacher-ng as of 0.8.0-3 (latest in Debian Jessie). This can results in unnecessary resource (bandwidth, storage) usage. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782643'
+    reason: 'http://httpredir.debian.org/debian is not included in the deb_mirrors.gz file of apt-cacher-ng as of 0.8.0-3 (latest in Debian Jessie). This can result in unnecessary resource (bandwidth, storage) usage. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782643'
     by_role: 'debops.apt_cacher_ng'
     delete: '{{ apt_cacher_ng__deploy_state != "present" }}'
 
@@ -527,9 +527,10 @@ apt_cacher_ng__nginx__upstream:
 
 # .. envvar:: apt_cacher_ng__nginx__servers
 #
-# List of :program:`nginx` server configurations managed by ``debops.nginx`` role.
-# There is separate configuration for HTTP and HTTPS connections to allow access
-# for hosts without SSL support installed.
+# List of :program:`nginx` server configurations managed by the
+# ``debops.nginx`` role.
+# There is a separate configuration for HTTP and HTTPS
+# connections to allow access for hosts without SSL support installed.
 apt_cacher_ng__nginx__servers:
 
   - by_role: 'debops.apt_cacher_ng'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -141,6 +141,24 @@ apt_cacher_ng__fqdn: 'software-cache.{{ ansible_domain }}'
 apt_cacher_ng__proxy: ''
 
 
+# .. envvar:: apt_cacher_ng__connect_protocol
+#
+# Specifies the IP protocol families to use for remote connections. Order does
+# matter, first specified are considered first.
+#
+# Example::
+#
+#    apt_cacher_ng__connect_protocol:
+#      - 'v4'
+#      # - 'v6'
+#
+# Only use IPv4 connections for connecting to upstream mirrors.
+#
+# Defaults to using native order of the system's TCP/IP stack, influenced by
+# the :any:`apt_cacher_ng__bind_address` value.
+apt_cacher_ng__connect_protocol: []
+
+
 # .. envvar:: apt_cacher_ng__offline_mode
 #
 # Forbid outgoing connections and work without an internet connection or

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -275,7 +275,7 @@ apt_cacher_ng__file_perms: '00644'
 #
 # ``lazy``
 #   Check the :file:`_expending_damaged` file in the root of
-#   ``apt_cacher_ng__cache_dir`` and only enforce permissions on all other
+#   :any:`apt_cacher_ng__cache_dir` and only enforce permissions on all other
 #   files if this one file needed to be changed.
 #
 # ``disabled``

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -490,7 +490,7 @@ apt_cacher_ng__ferm__dependent_rules:
     weight: '40'
     role: 'apt_cacher_ng'
     name: 'http_proxy'
-    delete: '{{ apt_cacher_ng__deploy_state != "present" }}'
+    rule_state: '{{ apt_cacher_ng__deploy_state }}'
 
 
 # .. envvar:: apt_cacher_ng__apparmor__dependent_config

--- a/templates/etc/apt-cacher-ng/acng.conf.j2
+++ b/templates/etc/apt-cacher-ng/acng.conf.j2
@@ -356,6 +356,9 @@ LocalDirs: acng-doc /usr/share/doc/apt-cacher-ng
 # BindAddress value.
 #
 # ConnectProto: v6 v4
+{% if apt_cacher_ng__connect_protocol|length >= 1 %}
+ConnectProto: {{ apt_cacher_ng__connect_protocol | join(" ") }}
+{% endif %}
 
 # Regular expiration algorithm finds package files which are no longer listed
 # in any index file and removes them of them after a safety period.


### PR DESCRIPTION
Seems I have broken IPv6 on a site. At least in this regard. I put the `ConnectProto` workaround in the config before `debops.apt_cacher_ng` has been written and now it seems I have to make this permanent because I verified it again with the default of `apt-cacher-ng` and it still results in:

```
# aptitude update
Ign http://httpredir.debian.org jessie InRelease
Get: 1 http://httpredir.debian.org jessie-updates InRelease [142 kB]
Get: 2 http://security.debian.org jessie/updates InRelease [63,1 kB]
Get: 3 http://httpredir.debian.org jessie-backports InRelease [166 kB]
Get: 4 http://security.debian.org jessie/updates/main i386 Packages [247 kB]
Get: 5 http://httpredir.debian.org stretch InRelease [232 kB]
Get: 6 http://security.debian.org jessie/updates/contrib i386 Packages [2.526 B]
Get: 7 http://security.debian.org jessie/updates/non-free i386 Packages [14 B]
Get: 8 http://security.debian.org jessie/updates/contrib Translation-en [1.211 B]
Get: 9 http://security.debian.org jessie/updates/main Translation-en [135 kB]
Get: 10 http://security.debian.org jessie/updates/non-free Translation-en [14 B]
Hit http://httpredir.debian.org jessie Release.gpg
Get: 11 http://httpredir.debian.org jessie-updates/main i386 Packages/DiffIndex [3.472 B]
Get: 12 http://httpredir.debian.org jessie-updates/contrib i386 Packages [32 B]
Get: 13 http://httpredir.debian.org jessie-updates/non-free i386 Packages/DiffIndex [736 B]
Get: 14 http://httpredir.debian.org jessie-updates/contrib Translation-en [14 B]
Ign http://httpredir.debian.org jessie-updates/main Translation-en/DiffIndex
Ign http://httpredir.debian.org jessie-updates/non-free Translation-en/DiffIndex
Ign http://httpredir.debian.org jessie-backports/main i386 Packages/DiffIndex
Ign http://httpredir.debian.org jessie-backports/contrib i386 Packages/DiffIndex
Ign http://httpredir.debian.org jessie-backports/non-free i386 Packages/DiffIndex
Ign http://httpredir.debian.org jessie-backports/contrib Translation-en/DiffIndex
Ign http://httpredir.debian.org jessie-backports/main Translation-en/DiffIndex
Ign http://httpredir.debian.org jessie-backports/non-free Translation-en/DiffIndex
Ign http://httpredir.debian.org stretch/main i386 Packages/DiffIndex
Ign http://httpredir.debian.org stretch/main Translation-en/DiffIndex
Ign http://httpredir.debian.org jessie Release
Ign http://httpredir.debian.org jessie/main i386 Packages/DiffIndex
Ign http://httpredir.debian.org jessie/contrib i386 Packages/DiffIndex
Ign http://httpredir.debian.org jessie/non-free i386 Packages/DiffIndex
Err http://httpredir.debian.org jessie-updates/main Translation-en
  500  Invalid header
Err http://httpredir.debian.org jessie-updates/non-free Translation-en
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/main i386 Packages
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/contrib i386 Packages
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/non-free i386 Packages
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/contrib Translation-en
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/main Translation-en
  500  Invalid header
Err http://httpredir.debian.org jessie-backports/non-free Translation-en
  500  Invalid header
Err http://httpredir.debian.org stretch/main i386 Packages
  500  Invalid header
Err http://httpredir.debian.org stretch/main Translation-en
  500  Invalid header
Ign http://httpredir.debian.org jessie/contrib Translation-en_US
Ign http://httpredir.debian.org jessie/contrib Translation-en
Ign http://httpredir.debian.org jessie/main Translation-en_US
Ign http://httpredir.debian.org jessie/main Translation-en
Ign http://httpredir.debian.org jessie/non-free Translation-en_US
Ign http://httpredir.debian.org jessie/non-free Translation-en
Err http://httpredir.debian.org jessie/main i386 Packages
  500  Invalid header
Err http://httpredir.debian.org jessie/contrib i386 Packages
  500  Invalid header
Err http://httpredir.debian.org jessie/non-free i386 Packages
  500  Invalid header
Fetched 995 kB in 11s (85,9 kB/s)
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/main/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/non-free/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/main/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/contrib/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/non-free/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/contrib/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/main/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-backports/non-free/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/stretch/main/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/stretch/main/i18n/Translation-en: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie/main/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie/contrib/binary-i386/Packages: 500  Invalid header
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie/non-free/binary-i386/Packages: 500  Invalid header
E: Some index files failed to download. They have been ignored, or old ones used instead.
E: Couldn't rebuild package cache
```

This is seems to be reproducible every time and from multiple clients. What I could do is to try another apt-cacher-ng installation. I will try this later.

I took a few hours to debug this now but I was not able to find the route cause.

The following options work around the problem (only one of them is sufficient):

* `ConnectProto: v4`
* `ReuseConnections: 0`

So it seems that the v6 setup of some mirrors of http://httpredir.debian.org/ might have trouble with open connections or something like this. But maybe it is just the ISP (VDSL German Telekom).

The following v6 hosts where connected by apt-cacher-ng when the error appeared:

* [2001:a78:5:1:216:35ff:fe7f:6ceb] lobos.debian.org
* [2a00:5ba0:8000:e:92e2:baff:fe36:3e88] ftp-b.stw-bonn.de

Related links:

* https://lists.alioth.debian.org/pipermail/apt-cacher-ng-users/2013-September/000082.html

So I am leaving it as it was using the `ConnectProto: v4` setting.