### PR TITLE
Revert "Use `rule_state` which is tagged for release in debops.ferm v0.2.2."

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -508,7 +508,7 @@ apt_cacher_ng__ferm__dependent_rules:
     weight: '40'
     role: 'apt_cacher_ng'
     name: 'http_proxy'
-    rule_state: '{{ apt_cacher_ng__deploy_state }}'
+    delete: '{{ apt_cacher_ng__deploy_state != "present" }}'
 
 
 # .. envvar:: apt_cacher_ng__apparmor__dependent_config


### PR DESCRIPTION
This reverts commit 4ee03108f09da265c127dea717d778b7fd0219a2.

This can’t possibly break it. It did pass before but I have no better idea why #7 is not passing.