### PR TITLE
Fix regression in the Debian upstream mirror selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,19 @@ The current role maintainer_ is ypid_.
 .. _debops.apt_cacher_ng master: https://github.com/debops/ansible-apt_cacher_ng/compare/v0.2.1...master
 
 
+`debops.apt_cacher_ng v0.2.2`_ - 2017-03-29
+-------------------------------------------
+
+.. _debops.apt_cacher_ng v0.2.2: https://github.com/debops/ansible-apt_cacher_ng/compare/v0.2.1...v0.2.2
+
+Fixed
+~~~~~
+
+- Fix regression in the Debian upstream mirror selection introduced in v0.2.1.
+  When the role was run against a non-Debian host then a mirror for another distribution
+  might have been selected as Debian mirror. [ypid_]
+
+
 `debops.apt_cacher_ng v0.2.1`_ - 2017-03-27
 -------------------------------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -195,9 +195,11 @@ apt_cacher_ng__max_download_speed_kib: ''
 # One mirror per line.
 # Set to an empty string to let the package scripts from Apt-Cacher NG decide
 # which upstream mirror to use.
-apt_cacher_ng__upstream_mirror_debian: '{{ ansible_local.apt.default_mirrors[0]
+apt_cacher_ng__upstream_mirror_debian: '{{ ansible_local.apt.default_sources_map.Debian[0]
                                            if (ansible_local|d() and ansible_local.apt|d() and
-                                             ansible_local.apt.default_mirrors|d())
+                                               ansible_local.apt.default_sources_map|d() and
+                                               ansible_local.apt.default_sources_map.Debian|d() and
+                                               ansible_local.apt.default_sources_map.Debian[0]|d())
                                            else "http://deb.debian.org/debian" }}'
 
                                                                    # ]]]
@@ -207,7 +209,12 @@ apt_cacher_ng__upstream_mirror_debian: '{{ ansible_local.apt.default_mirrors[0]
 # One mirror per line.
 # Set to an empty string to let the package scripts from Apt-Cacher NG decide
 # which upstream mirror to use.
-apt_cacher_ng__upstream_mirror_ubuntu: ''
+apt_cacher_ng__upstream_mirror_ubuntu: '{{ ansible_local.apt.default_sources_map.Ubuntu[0]
+                                           if (ansible_local|d() and ansible_local.apt|d() and
+                                               ansible_local.apt.default_sources_map|d() and
+                                               ansible_local.apt.default_sources_map.Ubuntu|d() and
+                                               ansible_local.apt.default_sources_map.Ubuntu[0]|d())
+                                           else "http://archive.ubuntu.com/ubuntu" }}'
 
                                                                    # ]]]
 # .. envvar:: apt_cacher_ng__upstream_mirror_gentoo [[[
@@ -216,7 +223,12 @@ apt_cacher_ng__upstream_mirror_ubuntu: ''
 # One mirror per line.
 # Set to an empty string to let the package scripts from Apt-Cacher NG decide
 # which upstream mirror to use.
-apt_cacher_ng__upstream_mirror_gentoo: ''
+apt_cacher_ng__upstream_mirror_gentoo: '{{ ansible_local.apt.default_sources_map.Gentoo[0]
+                                           if (ansible_local|d() and ansible_local.apt|d() and
+                                               ansible_local.apt.default_sources_map|d() and
+                                               ansible_local.apt.default_sources_map.Gentoo|d() and
+                                               ansible_local.apt.default_sources_map.Gentoo[0]|d())
+                                           else "" }}'
                                                                    # ]]]
                                                                    # ]]]
 # Cache directory [[[


### PR DESCRIPTION
@drybjed Seems we both missed that. Also, it might have been broken when the released `debops.apt_cacher_ng` role was used with the unreleased `debops.apt` role. This PR should fix this.

Uses, but does not depend on: https://github.com/debops/ansible-apt/pull/88