### PR TITLE
Update APT pinning to ensure new package version is installed on Jessie

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,16 @@ The current role maintainer_ is ypid_.
 
 .. _debops.apt_cacher_ng master: https://github.com/debops/ansible-apt_cacher_ng/compare/v0.2.1...master
 
+Fixed
+~~~~~
+
+- In Jessie, the backported ``apt-cacher-ng`` package now also requires a
+  backported ``libssl1.0.0`` package (and ``libssl-dev``, in case that is
+  installed). Update the APT pinning accordingly so that it is ensured that the
+  package is upgraded correctly and not kept back.
+  It might depend on your global APT pinning configuration if the package would
+  have been kept back without this or not. [ypid_]
+
 
 `debops.apt_cacher_ng v0.2.2`_ - 2017-03-29
 -------------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -497,7 +497,7 @@ apt_cacher_ng__etc_services__dependent_list:
 # Configuration for the debops.apt_preferences_ role.
 apt_cacher_ng__apt_preferences__dependent_list:
 
-  - package: 'apt-cacher-ng'
+  - package: 'apt-cacher-ng libssl*'
     backports: [ 'wheezy', 'jessie' ]
     reason: 'http://httpredir.debian.org/debian is not included in the deb_mirrors.gz file of apt-cacher-ng as of 0.8.0-3 (latest in Debian Jessie). This can result in unnecessary resource (bandwidth, storage) usage. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782643'
     by_role: 'debops.apt_cacher_ng'


### PR DESCRIPTION
@drybjed Out of curiosity, was it kept back on your systems as well? I guess this is because I use [apt_preferences__debian_stable_default_preset_list](https://docs.debops.org/en/latest/ansible/roles/ansible-apt_preferences/docs/defaults.html#apt-preference-presets).